### PR TITLE
[scripts/clean] Critical: Fix removing of kernel build dir. Prevented rebuild!!

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -19,7 +19,7 @@ base_dir="${BASE_DIR?}"
 				cat <<-EOF | bash
 					cd "$dir" || exit;
 					repo forall -c 'git reset --hard ; git clean --force -dx';
-					rm -rf out
+					rm -rf dist
 				EOF
 			}
 		) done


### PR DESCRIPTION
This fixes a critical bug in the clean script. Previously, the kernel was only build once and then was never cleaned and thus newer rebuild. This potentially prevented security fixes from getting build!!!